### PR TITLE
Missing terminating semi colon in render method of \Slim\Views\PhpRen…

### DIFF
--- a/src/PHPRenderer.php
+++ b/src/PHPRenderer.php
@@ -61,7 +61,7 @@ class PhpRenderer
         $render = function ($template, $data) {
             extract($data);
             include $template;
-        }
+        };
 
         ob_start();
         $render($this->templatePath . $template, $data);


### PR DESCRIPTION
Missing terminating semi colon in render method of \Slim\Views\PhpRenderer leading to syntax error.