### PR TITLE
Handle exceptions and throwables in templates

### DIFF
--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -62,7 +62,7 @@ class PhpRenderer
         $output = $this->fetch($template, $data);
 
         $response->getBody()->write($output);
-        
+
         return $response;
     }
 
@@ -164,9 +164,17 @@ class PhpRenderer
         */
         $data = array_merge($this->attributes, $data);
 
-        ob_start();
-        $this->protectedIncludeScope($this->templatePath . $template, $data);
-        $output = ob_get_clean();
+        try {
+            ob_start();
+            $this->protectedIncludeScope($this->templatePath . $template, $data);
+            $output = ob_get_clean();
+        } catch(\Throwable $e) { // PHP 7+
+            ob_end_clean();
+            throw $e;
+        } catch(\Exception $e) { // PHP < 7
+            ob_end_clean();
+            throw $e;
+        }
 
         return $output;
     }

--- a/tests/PhpRendererTest.php
+++ b/tests/PhpRendererTest.php
@@ -43,6 +43,32 @@ class PhpRendererTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("Hi", $newResponse->getBody()->getContents());
     }
 
+    public function testExceptionInTemplate() {
+        $renderer = new \Slim\Views\PhpRenderer("tests/");
+
+        $headers = new Headers();
+        $body = new Body(fopen('php://temp', 'r+'));
+        $response = new Response(200, $headers, $body);
+
+        try {
+            $newResponse = $renderer->render($response, "testException.php");
+        } catch (Throwable $t) { // PHP 7+
+            // Simulates an error template
+            $newResponse = $renderer->render($response, "testTemplate.php", [
+                "hello" => "Hi"
+            ]);
+        } catch (Exception $e) { // PHP < 7
+            // Simulates an error template
+            $newResponse = $renderer->render($response, "testTemplate.php", [
+                "hello" => "Hi"
+            ]);
+        }
+
+        $newResponse->getBody()->rewind();
+
+        $this->assertEquals("Hi", $newResponse->getBody()->getContents());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/tests/testException.php
+++ b/tests/testException.php
@@ -1,0 +1,9 @@
+Hello world. You should not see this because there is an error in the template.
+<?php
+$exception = new Exception('An error occurred');
+if($exception instanceof Throwable) {
+    echo 2/0;
+}
+
+throw $exception;
+?>


### PR DESCRIPTION
When an exception is thrown in the template, the output buffer should be cleaned up, so that a clean error message is shown to the user.

This PR handles PHP7 Throwables as well as being PHP 5.6 compatible.