### PR TITLE
Add leading slash if missing in setTemplatePath() too

### DIFF
--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -37,11 +37,7 @@ class PhpRenderer
      */
     public function __construct($templatePath = "", $attributes = [])
     {
-        $chr = substr($templatePath,-1);
-        if ($chr !== '/') {
-            $templatePath .= '/';
-        }
-        $this->templatePath = $templatePath;
+        $this->templatePath = rtrim($templatePath, '/\\') . '/';
         $this->attributes = $attributes;
     }
 
@@ -131,7 +127,7 @@ class PhpRenderer
      */
     public function setTemplatePath($templatePath)
     {
-        $this->templatePath = $templatePath;
+        $this->templatePath = rtrim($templatePath, '/\\') . '/';
     }
 
     /**


### PR DESCRIPTION
Noticed #27 and #28 just after I have encountered and fixed the issue on a fresh app.
Nevertheless here is my version, simpler and addresses the issue in the setter as well.

By the way, could a new version be tagged for Packagist?