### PR TITLE
Use func_get_arg(0) vs $template

### DIFF
--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -185,6 +185,6 @@ class PhpRenderer
      */
     protected function protectedIncludeScope ($template, array $data) {
         extract($data);
-        include $template;
+        include func_get_arg(0);
     }
 }


### PR DESCRIPTION
This makes it more-obvious to casual reviewers that $template cannot be replaced by the extract() call, and thus is not a security vulnerability.