### PR TITLE
Added minimal support for layouts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ $phpview->render($response, $template, $layout, ['data' => 'value']);
 
 // $response will now contain "<body>value</body>" the rendered view template inside layout
 ```
-Please note, the $content is special variable use inside layouts to render the wrapped view and should not be set
+Please note, the $content is special variable used inside layouts to render the wrapped view and should not be set
 in your view paramaters.
 
 ## Disabling Layouts
-If you don't want to make use of layouts, you can opt by simply passing false to `render` method.
+If you don't want to make use of layouts, you can opt out by simply passing false to `render` method.
 ```php
 $templateVariables = ['title' => 'Title'];
 
@@ -110,6 +110,7 @@ $templateVariables = ['title' => 'Title'];
  
  $phpview->render($response, './templates', false, ['more' => 'data'];
  // renders view without layout
+ ```
 ## Exceptions
 `\RuntimeException` - if template does not exist
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ include "vendor/autoload.php";
 
 $app = new Slim\App();
 $container = $app->getContainer();
-$container['renderer'] = new PhpRenderer("./templates");
+$container['renderer'] = new PhpRenderer("./templates" ./path/to/layouts');
 
 $app->get('/hello/{name}', function ($request, $response, $args) {
-    return $this->renderer->render($response, "/hello.php", $args);
+    return $this->renderer->render($response, "/hello.php", false, $args);
 });
 
 $app->run();
@@ -42,10 +42,10 @@ $app->run();
 ## Usage with any PSR-7 Project
 ```php
 //Construct the View
-$phpView = new PhpRenderer("./path/to/templates");
+$phpView = new PhpRenderer("./path/to/templates" ./path/to/layouts');
 
 //Render a Template
-$response = $phpView->render(new Response(), "/path/to/template.php", $yourData);
+$response = $phpView->render(new Response(), false, $yourData);
 ```
 
 ## Template Variables
@@ -57,7 +57,7 @@ You can now add variables to your renderer that will be available to all templat
 $templateVariables = [
     "title" => "Title"
 ];
-$phpView = new PhpRenderer("./path/to/templates", $templateVariables);
+$phpView = new PhpRenderer("./path/to/templates", ./path/to/layouts', $templateVariables);
 
 // or setter
 $phpView->setAttributes($templateVariables);
@@ -71,16 +71,45 @@ Data passed in via `->render()` takes precedence over attributes.
 $templateVariables = [
     "title" => "Title"
 ];
-$phpView = new PhpRenderer("./path/to/templates", $templateVariables);
+$phpView = new PhpRenderer("./path/to/templates", './path/to/layouts', '$templateVariables);
 
 //...
 
-$phpView->render($response, $template, [
+$phpView->render($response, $template, false, [
     "title" => "My Title"
 ]);
 // In the view above, the $title will be "My Title" and not "Title"
 ```
 
+## Rendering in Layouts
+You can now render view in another views called layouts, this allows you to compose modular view templates
+and help keep your views DRY.
+```php
+// via the constructor
+$templateVariables = [
+    "title" => "Title"
+];
+
+//create your layout ./path/to/layouts/default.phtml
+   <body> <?php print $content ?></body>
+
+$phpView = new PhpRenderer("./path/to/templates", './path/to/layouts', $templateVariables);
+$phpview->render($response, $template, $layout, ['data' => 'value']);
+
+// $response will now contain "<body>value</body>" the rendered view template inside layout
+```
+Please note, the $content is special variable use inside layouts to render the wrapped view and should not be set
+in your view paramaters.
+
+## Disabling Layouts
+If you don't want to make use of layouts, you can opt by simply passing false to `render` method.
+```php
+$templateVariables = ['title' => 'Title'];
+
+ $phpView = new PhpRenderer("./path/to/templates", ./path/to/layouts', $templateVariables);
+ 
+ $phpview->render($response, './templates', false, ['more' => 'data'];
+ // renders view without layout
 ## Exceptions
 `\RuntimeException` - if template does not exist
 

--- a/README.md
+++ b/README.md
@@ -91,18 +91,17 @@ $templateVariables = [
 ];
 
 //create your layout ./path/to/layouts/default.phtml
-   <body> <?php print $content ?></body>
-
+   //<body> <?php print $content ?></body>
+   
 $phpView = new PhpRenderer("./path/to/templates", './path/to/layouts', $templateVariables);
 $phpview->render($response, $template, $layout, ['data' => 'value']);
-
 // $response will now contain "<body>value</body>" the rendered view template inside layout
 ```
 Please note, the $content is special variable used inside layouts to render the wrapped view and should not be set
 in your view paramaters.
 
 ## Disabling Layouts
-If you don't want to make use of layouts, you can opt out by simply passing false to `render` method.
+If you don't want to make use of layouts, you can opt out by simply passing false as third argument to `render` method.
 ```php
 $templateVariables = ['title' => 'Title'];
 

--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -195,15 +195,15 @@ class PhpRenderer
         try {
             ob_start();
             $this->protectedIncludeScope($this->templatePath . $template, $data);
-            $output = ob_get_contents();
+            $output = ob_get_clean();
 
             if($layout !== false) {
+                ob_start();
                 $data = array_merge(['content' => $output], $this->attributes);
 
                 $this->protectedIncludeScope($this->layoutPath . $layout, $data);
                 $output = ob_get_clean();
             }
-            ob_get_clean();
         } catch(\Throwable $e) { // PHP 7+
             ob_end_clean();
             throw $e;

--- a/tests/PhpRendererTest.php
+++ b/tests/PhpRendererTest.php
@@ -177,7 +177,7 @@ class PhpRendererTest extends PHPUnit_Framework_TestCase
      */
     public function testLayoutNotFound() {
 
-        $renderer = new \Slim\Views\PhpRenderer("tests/");
+        $renderer = new \Slim\Views\PhpRenderer("tests/","tests/");
 
         $headers = new Headers();
         $body = new Body(fopen('php://temp', 'r+'));

--- a/tests/PhpRendererTest.php
+++ b/tests/PhpRendererTest.php
@@ -163,7 +163,7 @@ class PhpRendererTest extends PHPUnit_Framework_TestCase
      */
     public function testTemplateNotFound() {
 
-        $renderer = new \Slim\Views\PhpRenderer("tests/");
+        $renderer = new \Slim\Views\PhpRenderer("tests/", "tests/");
 
         $headers = new Headers();
         $body = new Body(fopen('php://temp', 'r+'));

--- a/tests/PhpRendererTest.php
+++ b/tests/PhpRendererTest.php
@@ -129,9 +129,7 @@ class PhpRendererTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testExceptionInlayout() {
         $renderer = new \Slim\Views\PhpRenderer("tests/","tests/");
 

--- a/tests/testLayout.php
+++ b/tests/testLayout.php
@@ -1,0 +1,1 @@
+<layout><?php print $content; ?></layout>


### PR DESCRIPTION
This PR adds ability to wrap view templates inside layouts. This is very simple implementation that just renders templates inside other templates called layouts. This PR doesn't support advanced techniques like template inheritance and extending as it would make the package heavy and conflict the SLIM principle.

Tests are in the tests directory and tests the same scenarios as original tests of the package.
Hope you like it!