### PR TITLE
Add fetchTemplate() method for layout-less rendering

### DIFF
--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -223,6 +223,56 @@ class PhpRenderer
     }
 
     /**
+     * Renders a template without a layout and returns the result as a string
+     *
+     * cannot contain template as a key
+     *
+     * throws RuntimeException if $templatePath . $template does not exist
+     *
+     * @param $template
+     * @param array $data
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException
+     * @throws \RuntimeException
+     */
+    public function fetchPartial($template, array $data = []) {
+        if (isset($data['template'])) {
+            throw new \InvalidArgumentException("Duplicate template key found");
+        }
+
+        if (!is_file($this->templatePath . $template)) {
+            throw new \RuntimeException("View cannot render `$template` because the template does not exist");
+        }
+
+
+        /*
+        foreach ($data as $k=>$val) {
+            if (in_array($k, array_keys($this->attributes))) {
+                throw new \InvalidArgumentException("Duplicate key found in data and renderer attributes. " . $k);
+            }
+        }
+        */
+        $data = array_merge($this->attributes, $data);
+
+        try {
+            ob_start();
+            $this->protectedIncludeScope($this->templatePath . $template, $data);
+            $output = ob_get_clean();
+
+        } catch(\Throwable $e) { // PHP 7+
+            ob_end_clean();
+            throw $e;
+        } catch(\Exception $e) { // PHP < 7
+            ob_end_clean();
+            throw $e;
+        }
+
+        return $output;
+    }
+
+    /**
      * @param string $template
      * @param array $data
      */

--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -66,7 +66,7 @@ class PhpRenderer
      */
     public function render(ResponseInterface $response, $template, array $data = [])
     {
-        $output = $this->fetch($template, $data);
+        $output = $this->fetch($template, $data, true);
 
         $response->getBody()->write($output);
 
@@ -174,13 +174,14 @@ class PhpRenderer
      *
      * @param $template
      * @param array $data
+     * @param bool $useLayout
      *
      * @return mixed
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function fetch($template, array $data = []) {
+    public function fetch($template, array $data = [], $useLayout = false) {
         if (isset($data['template'])) {
             throw new \InvalidArgumentException("Duplicate template key found");
         }
@@ -204,7 +205,7 @@ class PhpRenderer
             $this->protectedIncludeScope($this->templatePath . $template, $data);
             $output = ob_get_clean();
 
-            if ($this->layout !== null) {
+            if ($this->layout !== null && $useLayout) {
                 ob_start();
                 $data['content'] = $output;
                 $this->protectedIncludeScope($this->layout, $data);

--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -190,14 +190,6 @@ class PhpRenderer
             throw new \RuntimeException("View cannot render `$template` because the template does not exist");
         }
 
-
-        /*
-        foreach ($data as $k=>$val) {
-            if (in_array($k, array_keys($this->attributes))) {
-                throw new \InvalidArgumentException("Duplicate key found in data and renderer attributes. " . $k);
-            }
-        }
-        */
         $data = array_merge($this->attributes, $data);
 
         try {
@@ -246,14 +238,6 @@ class PhpRenderer
             throw new \RuntimeException("View cannot render `$template` because the template does not exist");
         }
 
-
-        /*
-        foreach ($data as $k=>$val) {
-            if (in_array($k, array_keys($this->attributes))) {
-                throw new \InvalidArgumentException("Duplicate key found in data and renderer attributes. " . $k);
-            }
-        }
-        */
         $data = array_merge($this->attributes, $data);
 
         try {

--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -215,7 +215,7 @@ class PhpRenderer
     }
 
     /**
-     * Renders a template without a layout and returns the result as a string
+     * Renders a template and returns the result as a string
      *
      * cannot contain template as a key
      *
@@ -229,7 +229,7 @@ class PhpRenderer
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function fetchPartial($template, array $data = []) {
+    public function fetchTemplate($template, array $data = []) {
         if (isset($data['template'])) {
             throw new \InvalidArgumentException("Duplicate template key found");
         }


### PR DESCRIPTION
When rendering partials, you often don't want it being wrapped in the template layout.
See: #49