### PR TITLE
Bugfix: Infinite loop in fetch

### DIFF
--- a/src/PhpRenderer.php
+++ b/src/PhpRenderer.php
@@ -66,7 +66,7 @@ class PhpRenderer
      */
     public function render(ResponseInterface $response, $template, array $data = [])
     {
-        $output = $this->fetch($template, $data);
+        $output = $this->fetch($template, $data, true);
 
         $response->getBody()->write($output);
 
@@ -174,13 +174,14 @@ class PhpRenderer
      *
      * @param $template
      * @param array $data
+     * @param bool $useLayout
      *
      * @return mixed
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    public function fetch($template, array $data = []) {
+    public function fetch($template, array $data = [], $useLayout = false) {
         if (isset($data['template'])) {
             throw new \InvalidArgumentException("Duplicate template key found");
         }
@@ -204,7 +205,7 @@ class PhpRenderer
             $this->protectedIncludeScope($this->templatePath . $template, $data);
             $output = ob_get_clean();
 
-            if ($this->layout !== null) {
+            if ($this->layout !== null && $useLayout) {
                 ob_start();
                 $data['content'] = $output;
                 $this->protectedIncludeScope($this->layout, $data);


### PR DESCRIPTION
Resolves https://github.com/slimphp/PHP-View/issues/49

Layout support added in v2.2.1 in this [PR](https://github.com/slimphp/PHP-View/pull/44) changed the way how fetch method works.

When there is a layout set and it or other template file calls fetch method, it creates an infinite loop:

- layout calls fetch method
- fetch method renders layout
- layout calls fetch method
- ...

which results in
```
Fatal error: Uncaught Error: Maximum function nesting level of '512' reached, aborting! 
```

While there is another attempt to fix the issue, https://github.com/slimphp/PHP-View/pull/52 it does so by introducing new method, while this PR introduces new argument in fetch method: `$useLayout` which defaults to false.