### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 matrix:
   include:
@@ -8,6 +8,7 @@ matrix:
   - php: 7.2
   - php: 7.3
   - php: 7.4
+  - php: 8.0
     env: ANALYSIS='true'
   - php: nightly
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "psr/http-message": "^1.0"
     },
     "autoload": {
@@ -20,8 +20,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "slim/psr7" : "^0.6",
+        "phpunit/phpunit": "^7.0 || ^8.5.8 || ^9.3",
+        "slim/psr7" : "^0.6 || ^1.0",
         "squizlabs/php_codesniffer": "^3.5"
     }
 }


### PR DESCRIPTION
 - Allow PHP 8 in `composer.json`
 - Allow PHPUnit 7.0 through 9.3. PHPUnit 9.3 supports PHP 8.0 and is the only official lowest version to do so. 
 - Prophecy is currently not allowing PHP 8.0, hence this being a draft PR. 