### PR TITLE
Add a .gitattributes file with export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests            export-ignore
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/.travis.yml      export-ignore
+/phpcs.xml        export-ignore
+/phpunit.xml.dist export-ignore
+
+*.php diff=php


### PR DESCRIPTION
Add a [`.gitattributes` file for the project](https://php.watch/articles/composer-gitattributes), so we can exclude test and other build files from composer `prefer-dist` installations.
With this PR merged, the dist size of this package will be ~45% smaller.