### PR TITLE
Update `.gitattributes` file with recent changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
+/.github          export-ignore
 /tests            export-ignore
 /.gitattributes   export-ignore
 /.gitignore       export-ignore
-/.travis.yml      export-ignore
 /phpcs.xml        export-ignore
 /phpunit.xml.dist export-ignore
 


### PR DESCRIPTION
Updates `.gitattributes` file to account for the removal of Travis CI file and the new `.github` directory with `export-ignore` directives.