### PR TITLE
Upgrade GitHub actions checkout to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This PR fixes the build warning: 

`The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v2`