### PR TITLE
Passing null to parameter #1 ($string) is deprecated in htmlspecialchars() function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,12 @@ The following function uses the `htmlspecialchars` function
 with specific flags to ensure proper encoding:
 
 ```php
-function html(string $text = null): string
+function html(?string $text = null): string
 {
+    if (null === $text) {
+        return '';
+    }
+
     return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 }
 ```


### PR DESCRIPTION
Deprecated: htmlspecialchars(): Passing null to parameter `#1` ($string) of type string is deprecated.