### PR TITLE
Support 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 7.4, 8.0, 8.1, 8.2, 8.3 ]
+        php: [ 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5 ]
 
     steps:
       - name: Checkout

--- a/tests/PhpRendererTest.php
+++ b/tests/PhpRendererTest.php
@@ -139,7 +139,9 @@ class PhpRendererTest extends TestCase
         $body = $this->createStream();
         $response = new Response(200, $headers, $body);
         try {
-            $newResponse = $renderer->render($response, 'template.phtml');
+            $newResponse = $renderer->render($response, 'template.phtml', [
+                'hello' => 'Hi'
+            ]);
         } catch (Throwable $t) {
             // PHP 7+
             // Simulates an error template


### PR DESCRIPTION
 Fix a PHP warning in `testExceptionInLayout()` and add PHP 8.4 and 8.5 to the CI matrix.
 
Note that PHP 8.5 isn't released yet.